### PR TITLE
Update podspec to be able to get only XMLResponseSerializer

### DIFF
--- a/AlamofireXMLRPC.podspec
+++ b/AlamofireXMLRPC.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name         = "AlamofireXMLRPC"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "AlamofireXMLRPC aims to provide an easy way to perform call on XML RPC service and allows to retrieve smoothly the response"
   s.homepage     = "https://github.com/kodlian/AlamofireXMLRPC"
 
@@ -20,9 +20,19 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.10"
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.source       = { :git => "https://github.com/kodlian/AlamofireXMLRPC.git", :tag => "1.0.0" }
+  s.source       = { :git => "https://github.com/kodlian/AlamofireXMLRPC.git", :tag => s.version }
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.source_files  = "AlamofireXMLRPC/*.swift"
+  s.default_subspec = 'XMLRPC'
+
+  s.subspec "XML" do  |sp|
+    sp.source_files = "AlamofireXMLRPC/Alamofire+XML.swift"
+  end
+
+  s.subspec "XMLRPC" do  |sp|
+    sp.source_files = "AlamofireXMLRPC/*.swift"
+    sp.exclude_files = "AlamofireXMLRPC/Alamofire+XML.swift"
+    sp.dependency 'AlamofireXMLRPC/XML'
+  end
 
   #  Dependency
   s.dependency 'Alamofire'


### PR DESCRIPTION
by using subspec

tested with

```
  pod 'AlamofireXMLRPC/XML', :git => 'https://github.com/phimage/AlamofireXMLRPC.git', :branch => 'feature-subspec' 
```

and 

```
  pod 'AlamofireXMLRPC', :git => 'https://github.com/phimage/AlamofireXMLRPC.git', :branch => 'feature-subspec' 
```

I updated the version, so need to push a tag after merging
