### PR TITLE
Go one level deeper when converting to an array.

### DIFF
--- a/AlamofireXMLRPC/XML.swift
+++ b/AlamofireXMLRPC/XML.swift
@@ -155,7 +155,7 @@ public struct XMLRPCNode {
     public var array: [XMLRPCNode]? {
         if let children = xml.rpcChildren {
             return children.map { e in
-                if let value = e.first {
+                if let value = e.children.first {
                     return XMLRPCNode(xml: value)
                 }
                 return self.dynamicType.errorNode


### PR DESCRIPTION
Resolves #3.

I encountered what I believe to be the same issue as described in #3—I'd convert to an array and get an array of the first value repeated for each element rather than the correct non-first values.  In poking at the code, there's something about `children.map` that yields elements that behave like they're at the parent level.  Inserting the `.children` in the `if let` resolved the issue.
