### PR TITLE
rawXML variable

### DIFF
--- a/AlamofireXMLRPC/XMLRPCNode.swift
+++ b/AlamofireXMLRPC/XMLRPCNode.swift
@@ -18,7 +18,8 @@ public struct XMLRPCNode {
     }()
 
     var xml: AEXMLElement
-
+    public var rawXML: String
+    
     init( xml rootXML: AEXMLElement) {
         var xml = rootXML
         while (xml.rpcNode == .value || xml.rpcNode == .parameter) &&  xml.children.count > 0 {
@@ -27,6 +28,7 @@ public struct XMLRPCNode {
             }
         }
         self.xml = xml
+        self.rawXML = xml.xml
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -227,5 +227,15 @@ var data: Data?
 var count: Int?
 ```
 
+#### Raw XML string
+
+For purpoises of debugging you can also get raw xml string this way:
+
+```swift
+case .success(let value):
+        var raw = value.rawXML
+        print(raw)
+```
+
 ## License
 AlamofireXMLRPC is released under the MIT license. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ var count: Int?
 
 #### Raw XML string
 
-For purpoises of debugging you can also get raw xml string this way:
+For purposes of debugging you can also get raw xml string this way:
 
 ```swift
 case .success(let value):


### PR DESCRIPTION
I created variable `rawXML` in struct `XMLRPCNode`. This is what I needed very much when was using this library.
