### PR TITLE
Update AlamofireXMLRPC.podspec

### DIFF
--- a/AlamofireXMLRPC.podspec
+++ b/AlamofireXMLRPC.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.source       = { :git => "https://github.com/kodlian/AlamofireXMLRPC.git", :tag => "2.2.0" }
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.source_files  = "Sources/*.swift"
+  s.source_files  = "Sources/AlamofireXMLRPC/*.swift"
 
   #  Dependency
   s.dependency 'Alamofire'


### PR DESCRIPTION
### Abstract 
After install 2.2.0, there are no swift files.

-----

<img width="223" alt="no pod file" src="https://user-images.githubusercontent.com/4126751/30798373-b6d355a2-a1d9-11e7-9495-0253fcbf13ba.png">


------

