### PR TITLE
Filter out control characters

### DIFF
--- a/Sources/AlamofireXMLRPC/Alamofire+XML.swift
+++ b/Sources/AlamofireXMLRPC/Alamofire+XML.swift
@@ -22,17 +22,8 @@ extension DataRequest {
             }
 
             do {
-                // Filter control characters
-                if var text = String(data: validData, encoding: .utf8) {
-                    // control character excludes \n \t \r
-                    let sets = CharacterSet.controlCharacters.subtracting(CharacterSet(charactersIn: "\n\t\r"))
-                    text = text.components(separatedBy: sets).joined()
-                    let XML = try AEXMLDocument(xml: text)
-                    return .success(XML)
-                } else {
-                    let XML = try AEXMLDocument(xml: validData)
-                    return .success(XML)
-                }
+                let XML = try AEXMLDocument(xml: validData)
+                return .success(XML)
             } catch {
                 return .failure(error)
             }

--- a/Sources/AlamofireXMLRPC/Alamofire+XML.swift
+++ b/Sources/AlamofireXMLRPC/Alamofire+XML.swift
@@ -22,8 +22,17 @@ extension DataRequest {
             }
 
             do {
-                let XML = try AEXMLDocument(xml: validData)
-                return .success(XML)
+                // Filter control characters
+                if var text = String(data: validData, encoding: .utf8) {
+                    // control character excludes \n \t \r
+                    let sets = CharacterSet.controlCharacters.subtracting(CharacterSet(charactersIn: "\n\t\r"))
+                    text = text.components(separatedBy: sets).joined()
+                    let XML = try AEXMLDocument(xml: text)
+                    return .success(XML)
+                } else {
+                    let XML = try AEXMLDocument(xml: validData)
+                    return .success(XML)
+                }
             } catch {
                 return .failure(error)
             }

--- a/Sources/AlamofireXMLRPC/Alamofire+XML.swift
+++ b/Sources/AlamofireXMLRPC/Alamofire+XML.swift
@@ -22,8 +22,17 @@ extension DataRequest {
             }
 
             do {
-                let XML = try AEXMLDocument(xml: validData)
-                return .success(XML)
+                // Filter out control characters
+                if var text = String(data: validData, encoding: .utf8) {
+                    // Filter out all control characters except \n \t \r before parsing the XML
+                    let sets = CharacterSet.controlCharacters.subtracting(CharacterSet(charactersIn: "\n\t\r"))
+                    text = text.components(separatedBy: sets).joined()
+                    let XML = try AEXMLDocument(xml: text)
+                    return .success(XML)
+                } else {
+                    let XML = try AEXMLDocument(xml: validData)
+                    return .success(XML)
+                }
             } catch {
                 return .failure(error)
             }


### PR DESCRIPTION
Parsing may fail if the XML contains some control characters, such as 28 in ASCII.
Filter out all control characters except \n \t \r before parsing the XML.